### PR TITLE
New release without `failure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 0.9.0 - 2020-03-13
+
+- `failure` has been replaced by the combination of the `thiserror` and
+  `anyhow` crates. (#11)
+
 ## 0.8.0 - 2020-03-10
 
 - `bitcoin` dependency has been updated to the new major release `0.23`. (#10)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btc-transaction-utils"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 description = "A collection of helpers for signing bitcoin transactions with segwit."
 authors = ["The Exonum Team <exonum@bitfury.com>"]
@@ -14,8 +14,8 @@ keywords = ["crypto", "bitcoin", "segwit"]
 [dependencies]
 bitcoin = "0.23"
 bitcoin_hashes = "0.7"
-failure = "0.1"
-failure_derive = "0.1"
+thiserror = "1.0"
+anyhow = "1.0"
 hex = "0.4"
 rand = "0.6"
 secp256k1 = { version = "0.17", features = ["rand"] }

--- a/exonum-dictionary.txt
+++ b/exonum-dictionary.txt
@@ -3,8 +3,8 @@ aricent
 atomicity
 backend
 bigint
-Bitbucket
 bitbucket
+Bitbucket
 bitcoind
 bitcoinrpc
 bitfury
@@ -64,8 +64,8 @@ librocksdb
 libsnappy
 libsodium
 libssl
-Mainnet
 mainnet
+Mainnet
 maintainer's
 markdownlint
 memorydb
@@ -100,8 +100,8 @@ PUSHBYTES
 PUSHNUM
 readonly
 reddit
-Regtest
 regtest
+Regtest
 reimplemented
 repo
 repos
@@ -148,6 +148,7 @@ testdata
 testkit
 testnet
 testnetctl
+thiserror
 timestamping
 timestamps
 tlsdate

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -26,9 +26,8 @@ use bitcoin::{
     util::psbt::serialize::Serialize,
     PublicKey,
 };
-use failure;
-use failure_derive::Fail;
 use hex;
+use thiserror::Error;
 
 use std::{fmt, str::FromStr};
 
@@ -57,7 +56,7 @@ impl fmt::Display for RedeemScript {
 }
 
 impl FromStr for RedeemScript {
-    type Err = failure::Error;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let script = Script::from(hex::decode(s)?);
@@ -254,19 +253,19 @@ impl Default for RedeemScriptBuilder {
 }
 
 /// Possible errors related to the redeem script.
-#[derive(Debug, Copy, Clone, Fail, PartialEq)]
+#[derive(Debug, Copy, Clone, Error, PartialEq)]
 pub enum RedeemScriptError {
     /// Not enough keys for the quorum.
-    #[fail(display = "Not enough keys for the quorum.")]
+    #[error("Not enough keys for the quorum.")]
     IncorrectQuorum,
     /// Quorum was not set during the redeem script building.
-    #[fail(display = "Quorum was not set.")]
+    #[error("Quorum was not set.")]
     NoQuorum,
     /// Not enough public keys. At least one public key must be specified.
-    #[fail(display = "Not enough public keys. At least one public key must be specified.")]
+    #[error("Not enough public keys. At least one public key must be specified.")]
     NotEnoughPublicKeys,
     /// Given script is not the standard redeem script.
-    #[fail(display = "Given script is not the standard redeem script.")]
+    #[error("Given script is not the standard redeem script.")]
     NotStandard,
 }
 


### PR DESCRIPTION
`failure` has been replaced by the combination of the `thiserror` and `anyhow` crates.